### PR TITLE
Add possibility to use ip address for registration

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -29,6 +29,7 @@ type ConsulConfig struct {
 	Scheme       string   `env:"RP_CONSUL_SCHEME" envDefault:"http"`
 	Token        string   `env:"RP_CONSUL_TOKEN"`
 	PollInterval int      `env:"RP_CONSUL_POLL_INTERVAL" envDefault:"5"`
+	PreferIP     bool     `env:"RP_CONSUL_PREFER_IP_ADDRESS" envDefault:"false"`
 	Tags         []string `env:"RP_CONSUL_TAGS"`
 }
 

--- a/registry/consul.go
+++ b/registry/consul.go
@@ -25,15 +25,19 @@ func NewConsul(cfg *conf.RpConfig) ServiceDiscovery {
 		log.Fatal("Cannot create Consul client!")
 	}
 
-	baseURL := HTTP + cfg.Server.Hostname + ":" + strconv.Itoa(cfg.Server.Port)
+	host := cfg.Server.Hostname
+	if cfg.Consul.PreferIP {
+		host = commons.GetLocalIP()
+	}
+
 	registration := &api.AgentServiceRegistration{
-		ID:      fmt.Sprintf("%s-%s-%d", cfg.AppName, cfg.Server.Hostname, cfg.Server.Port),
+		ID:      fmt.Sprintf("%s-%s-%d", cfg.AppName, host, cfg.Server.Port),
 		Port:    cfg.Server.Port,
 		Address: commons.GetLocalIP(),
 		Name:    cfg.AppName,
 		Tags:    cfg.Consul.Tags,
 		Check: &api.AgentServiceCheck{
-			HTTP:     baseURL + "/health",
+			HTTP:     HTTP + host + ":" + strconv.Itoa(cfg.Server.Port) + "/health",
 			Interval: fmt.Sprintf("%ds", cfg.Consul.PollInterval),
 		},
 	}


### PR DESCRIPTION
This pull request is to have similar possibility for go as for java microservices.
We can override consul vonfig for java,"Value": "{\"spring\":{\"cloud\":{\"consul\":{\"discovery\":{\"prefer-ip-address\": \"true\"}}}}}"
                            
But not for Go, as it is hardcoded to use hostname, and not ip always.

We need to use ip adress to deploy RP in AWS cluster, this can solve also 
https://github.com/reportportal/reportportal/issues/560 as we created it as a part of our RP installation.

Suggested solution is to introduce env variable to have a choice, when it is necessary.